### PR TITLE
Copy CP/DP Makefile from ngic-rtc repo

### DIFF
--- a/Jenkinsfile-omec-test-TC1.groovy
+++ b/Jenkinsfile-omec-test-TC1.groovy
@@ -320,7 +320,7 @@ node("${params.executorNode}") {
         timeout(3) {
           waitUntil {
             ngic_rtc_cp_output = sh returnStdout: true, script: """
-            ssh ngic-cp1 'cp -f ${basedir_config}/zmq-ng-core_cfg.mk ${basedir_cp1}/ngic-rtc/config/ng-core_cfg.mk'
+            ssh ngic-cp1 'cp -f ${basedir_cp1}/ngic-rtc/.ci/tc1/cp/custom-cp.mk ${basedir_cp1}/ngic-rtc/cp/custom-cp.mk'
             ssh ngic-cp1 'cd ${basedir_cp1}/ngic-rtc/cp && source ../setenv.sh && make clean && make'
             sleep 2
             """
@@ -352,8 +352,7 @@ node("${params.executorNode}") {
           }
           waitUntil {
             ngic_rtc_dp_output = sh returnStdout: true, script: """
-            ssh ngic-dp1 'cp -f ${basedir_config}/zmq-ng-core_cfg.mk ${basedir_dp1}/ngic-rtc/config/ng-core_cfg.mk'
-            ssh ngic-dp1 'cp -f ${basedir_config}/kni_Makefile ${basedir_dp1}/ngic-rtc/dp/Makefile'
+            ssh ngic-dp1 'cp -f ${basedir_dp1}/ngic-rtc/.ci/tc1/dp/custom-dp.mk ${basedir_dp1}/ngic-rtc/dp/custom-dp.mk'
             ssh ngic-dp1 'cd ${basedir_dp1}/ngic-rtc/dp && source ../setenv.sh && make clean && make'
             """
             echo "${ngic_rtc_dp_output}"

--- a/Jenkinsfile-omec-test-TC2.groovy
+++ b/Jenkinsfile-omec-test-TC2.groovy
@@ -332,7 +332,7 @@ node("${params.executorNode}") {
         timeout(3) {
           waitUntil {
             ngic_rtc_cp_output = sh returnStdout: true, script: """
-            ssh ngic-cp1 'cp -f ${basedir_config}/udp-ng-core_cfg.mk ${basedir_cp1}/ngic-rtc/config/ng-core_cfg.mk'
+            ssh ngic-cp1 'cp -f ${basedir_cp1}/ngic-rtc/.ci/tc2/cp/custom-cp.mk ${basedir_cp1}/ngic-rtc/cp/custom-cp.mk'
             ssh ngic-cp1 'cd ${basedir_cp1}/ngic-rtc/cp && source ../setenv.sh && make clean && make'
             sleep 2
             """
@@ -364,9 +364,8 @@ node("${params.executorNode}") {
           }
           waitUntil {
             ngic_rtc_dp_output = sh returnStdout: true, script: """
-            ssh ngic-dp1 'cp -f ${basedir_config}/udp-ng-core_cfg.mk ${basedir_dp1}/ngic-rtc/config/ng-core_cfg.mk'
             ssh ngic-dp1 'cp -f ${basedir_config}/udp-static_arp.cfg ${basedir_dp1}/ngic-rtc/config/static_arp.cfg'
-            ssh ngic-dp1 'cp -f ${basedir_config}/static_arp_Makefile ${basedir_dp1}/ngic-rtc/dp/Makefile'
+            ssh ngic-dp1 'cp -f ${basedir_dp1}/ngic-rtc/.ci/tc2/dp/custom-dp.mk ${basedir_dp1}/ngic-rtc/dp/custom-dp.mk'
             ssh ngic-dp1 'cd ${basedir_dp1}/ngic-rtc/dp && source ../setenv.sh && make clean && make'
             """
             echo "${ngic_rtc_dp_output}"


### PR DESCRIPTION
Use CP/DP Makefile stored in .ci directory in ngic-rtc repo, instead
of handling configurations for ZMQ/KNI and UDP/Static_ARP with local
copies of Makefile.

resolve #11