### PR TITLE
Rebase PRs when cloning repos during install

### DIFF
--- a/Jenkinsfile-omec-install-c3po-vnf.groovy
+++ b/Jenkinsfile-omec-install-c3po-vnf.groovy
@@ -114,7 +114,7 @@ node("${params.executorNode}") {
 
                 if [ ${params.ghprbGhRepository} = ${ghRepository} ]; then
                     git fetch origin pull/${params.ghprbPullId}/head:jenkins_test || exit 1
-                    git checkout jenkins_test || exit 1
+                    git rebase master jenkins_test || exit 1
                     git log -1
                 fi
                 '
@@ -170,7 +170,7 @@ node("${params.executorNode}") {
 
                 if [ ${params.ghprbGhRepository} = ${ghRepository} ]; then
                     git fetch origin pull/${params.ghprbPullId}/head:jenkins_test || exit 1
-                    git checkout jenkins_test || exit 1
+                    git rebase master jenkins_test || exit 1
                     git log -1
                 fi
                 '

--- a/Jenkinsfile-omec-install-ngic-rtc-vnf.groovy
+++ b/Jenkinsfile-omec-install-ngic-rtc-vnf.groovy
@@ -89,7 +89,7 @@ node("${params.executorNode}") {
 
                 if [ ${params.ghprbGhRepository} = ${ghRepository} ]; then
                     git fetch origin pull/${params.ghprbPullId}/head:jenkins_test || exit 1
-                    git checkout jenkins_test || exit 1
+                    git rebase master jenkins_test || exit 1
                     git log -1
                 fi
 
@@ -123,7 +123,7 @@ node("${params.executorNode}") {
 
                 if [ ${params.ghprbGhRepository} = ${ghRepository} ]; then
                     git fetch origin pull/${params.ghprbPullId}/head:jenkins_test || exit 1
-                    git checkout jenkins_test || exit 1
+                    git rebase master jenkins_test || exit 1
                     git log -1
                 fi
 

--- a/Jenkinsfile-omec-install-openmme-vnf.groovy
+++ b/Jenkinsfile-omec-install-openmme-vnf.groovy
@@ -91,7 +91,7 @@ node("${params.executorNode}") {
 
                 if [ ${params.ghprbGhRepository} = ${ghRepository} ]; then
                     git fetch origin pull/${params.ghprbPullId}/head:jenkins_test || exit 1
-                    git checkout jenkins_test || exit 1
+                    git rebase master jenkins_test || exit 1
                     git log -1
                 fi
 


### PR DESCRIPTION
Rebase a Pull Request onto master branch when cloning a repo during the
VNF install phase.
In this way CICD tests are run using the latest status of the repo plus
the PR.