### PR TITLE
Add delay between load-tester stop.sh/start.sh

### DIFF
--- a/Jenkinsfile-omec-test-TC1.groovy
+++ b/Jenkinsfile-omec-test-TC1.groovy
@@ -468,6 +468,7 @@ node("${params.executorNode}") {
               if pgrep -f [n]ettest; then pkill -f [n]ettest; fi
               # service hipped restart
               cd /opt/polaris-load-tester && ./stop.sh
+              sleep 2
               cd /opt/polaris-load-tester && ./start.sh
               sleep 5
               [[ \$(ps -ef | grep "[t]clsh NetTest-Server.tcl" | grep -v grep | wc -l) -eq 3 ]] || exit 1


### PR DESCRIPTION
Add a delay before restarting polaris-load-tester, in order to allow a
graceful stop and start.

Sometimes, processes cannot be restarted as not completely stopped yet.

resolve #23