### PR TITLE
TC1: add time traces in DP configuration

### DIFF
--- a/Jenkinsfile-omec-test-TC1.groovy
+++ b/Jenkinsfile-omec-test-TC1.groovy
@@ -419,9 +419,10 @@ node("${params.executorNode}") {
                 cd ${basedir_dp1}/ngic-rtc/dp
                 stdbuf -o0 ./run.sh 1>${dp_stdout_log} 2>${dp_stderr_log} &
 
-                sleep 10
+                date +"%Y-%m-%d %H:%M:%S.%3N"
+                sleep 20;
+                date +"%Y-%m-%d %H:%M:%S.%3N"
 
-                sleep 10
                 cd ${basedir_dp1}/ngic-rtc/kni_ifcfg && ./kni-SGIdevcfg.sh
                 cd ${basedir_dp1}/ngic-rtc/kni_ifcfg && ./kni-S1Udevcfg.sh
                 '


### PR DESCRIPTION
Use only one 'sleep' instruction and add time traces to make sure that
kni interfaces are configured when DP is up and running.

Sometimes, errors have been observed in console output, as if the
'sleep' instruction is not considered.