### PR TITLE
Make tests fail if PR is not based on master HEAD

### DIFF
--- a/Jenkinsfile-omec-install-c3po-hss-vnf.groovy
+++ b/Jenkinsfile-omec-install-c3po-hss-vnf.groovy
@@ -51,9 +51,28 @@ node("${params.executorNode}") {
               cd c3po
 
               if [ ${params.ghprbGhRepository} = ${ghRepository} ]; then
+                  # Clone repo.
                   git fetch origin pull/${params.ghprbPullId}/head:jenkins_test || exit 1
-                  git rebase master jenkins_test || exit 1
+                  git checkout jenkins_test
                   git log -1
+
+                  # Check that the merge base between master and PR is master HEAD.
+                  if [[ \$(git merge-base jenkins_test master) != \$(git rev-parse master) ]]; then
+
+                      message=(
+                          ""
+                          "*******************************************"
+                          "*                                         *"
+                          "* PR is not based on current master HEAD. *"
+                          "* Please rebase your code on master.      *"
+                          "*                                         *"
+                          "*******************************************"
+                          ""
+                      )
+                      printf "%s\\n" "\${message[@]}"
+
+                      exit 1
+                  fi
               fi
               '
           """

--- a/Jenkinsfile-omec-install-c3po-sgx-vnf.groovy
+++ b/Jenkinsfile-omec-install-c3po-sgx-vnf.groovy
@@ -53,9 +53,28 @@ node("${params.executorNode}") {
               cd c3po
 
               if [ ${params.ghprbGhRepository} = ${ghRepository} ]; then
+                  # Clone repo.
                   git fetch origin pull/${params.ghprbPullId}/head:jenkins_test || exit 1
-                  git rebase master jenkins_test || exit 1
+                  git checkout jenkins_test
                   git log -1
+
+                  # Check that the merge base between master and PR is master HEAD.
+                  if [[ \$(git merge-base jenkins_test master) != \$(git rev-parse master) ]]; then
+
+                      message=(
+                          ""
+                          "*******************************************"
+                          "*                                         *"
+                          "* PR is not based on current master HEAD. *"
+                          "* Please rebase your code on master.      *"
+                          "*                                         *"
+                          "*******************************************"
+                          ""
+                      )
+                      printf "%s\\n" "\${message[@]}"
+
+                      exit 1
+                  fi
               fi
               '
           """

--- a/Jenkinsfile-omec-install-ngic-rtc-vnf.groovy
+++ b/Jenkinsfile-omec-install-ngic-rtc-vnf.groovy
@@ -88,9 +88,28 @@ node("${params.executorNode}") {
                 cd ngic-rtc
 
                 if [ ${params.ghprbGhRepository} = ${ghRepository} ]; then
+                    # Clone repo.
                     git fetch origin pull/${params.ghprbPullId}/head:jenkins_test || exit 1
-                    git rebase master jenkins_test || exit 1
+                    git checkout jenkins_test
                     git log -1
+
+                    # Check that the merge base between master and PR is master HEAD.
+                    if [[ \$(git merge-base jenkins_test master) != \$(git rev-parse master) ]]; then
+
+                        message=(
+                            ""
+                            "*******************************************"
+                            "*                                         *"
+                            "* PR is not based on current master HEAD. *"
+                            "* Please rebase your code on master.      *"
+                            "*                                         *"
+                            "*******************************************"
+                            ""
+                        )
+                        printf "%s\\n" "\${message[@]}"
+
+                        exit 1
+                    fi
                 fi
 
                 # These files are copied in order to have a working config after this script is run.


### PR DESCRIPTION
Require that Pull Request is rebased on current HEAD of master before
testing:

-. check that Pull Request is based on current master HEAD
-. fail otherwise

Rebase on master is not carried out automatically by the script, to
avoid that tested code differs from what developers have pushed.

resolve #40